### PR TITLE
Update BCP value for 2023

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,7 +1,7 @@
 /**
- * Valor BPC 2022.
+ * Valor BPC 2023.
  */
-const BPC = 5164;
+const BPC = 5660;
 
 /**
  * Franjas de IPRF.


### PR DESCRIPTION
In accordance with the following:
https://mediospublicos.uy/ejecutivo-aumento-valor-de-bpc-que-paso-a-ser-5-660-pesos/

BPC value has been updated